### PR TITLE
feat: implement update checker and configurable messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This allows server admins to easily separate Java and Bedrock permissions (e.g.,
 | :--- | :--- | :--- |
 | `/junction` | None | Displays plugin version info. |
 | `/junction reload` | `junction.reload` | Reloads the configuration. |
+| N/A | `junction.admin` | Receive update notifications. |
 
 ## Configuration
 
@@ -36,6 +37,17 @@ permissions:
   provider: LuckPerms
   # Which permission group should players be assigned to?
   group: geyser
+# Settings related to messages sent by the plugin.
+messages:
+  # Prefix for all messages sent by the plugin.
+  prefix: <color:#00D4FF><bold>Junction</bold> ➟ </color>
+  # Message displayed when the plugin is reloaded.
+  reloadSuccess: Plugin configuration has been reloaded successfully.
+  # Message displayed when the plugin fails to reload.
+  reloadFail: <red>Failed to reload plugin configuration! Check console for errors.</red>
+  # Message displayed when a new version of the plugin is available.
+  updateAvailable: 'A new version is available! <gray>(Current: <red>{current_version}</red>
+    | Latest: <green>{latest_version}</green>)</gray>'
 ```
 
 ## Building

--- a/src/main/java/com/muhdfdeen/junction/Junction.java
+++ b/src/main/java/com/muhdfdeen/junction/Junction.java
@@ -1,6 +1,5 @@
 package com.muhdfdeen.junction;
 
-import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 
@@ -13,6 +12,7 @@ import com.muhdfdeen.junction.listener.PlayerJoinListener;
 import com.muhdfdeen.junction.permission.PermissionProvider;
 import com.muhdfdeen.junction.permission.ProviderManager;
 import com.muhdfdeen.junction.util.Logger;
+import com.muhdfdeen.junction.util.UpdateChecker;
 
 public final class Junction extends JavaPlugin {
     private static Junction plugin;
@@ -24,13 +24,17 @@ public final class Junction extends JavaPlugin {
     public void onEnable() {
         plugin = this;
         this.log = new Logger(this);
+        UpdateChecker updateChecker = new UpdateChecker(this);
+        updateChecker.checkForUpdates();
         if (!reload()) {
             log.error("Disabling plugin due to critical configuration error.");
             getServer().getPluginManager().disablePlugin(this);
             return;
         }
+        @SuppressWarnings("unused")
         Metrics metrics = new Metrics(this, 28238);
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(this), this);
+        getServer().getPluginManager().registerEvents(updateChecker, this);
         this.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> {
             JunctionCommand junctionCommand = new JunctionCommand(this);
             event.registrar().register(junctionCommand.createCommand("junction"), "Main Junction command");

--- a/src/main/java/com/muhdfdeen/junction/command/JunctionCommand.java
+++ b/src/main/java/com/muhdfdeen/junction/command/JunctionCommand.java
@@ -9,9 +9,9 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 
 import com.muhdfdeen.junction.Junction;
+import com.muhdfdeen.junction.config.Config.MainConfiguration; 
 
 public class JunctionCommand {
-    private static final String PREFIX = "<color:#00D4FF><bold>Junction</bold> ➟ </color>";
     private final Junction plugin;
 
     public JunctionCommand(Junction plugin) {
@@ -19,10 +19,11 @@ public class JunctionCommand {
     }
 
     public LiteralCommandNode<CommandSourceStack> createCommand(final String commandName) {
+        MainConfiguration config = plugin.getConfiguration();
         return Commands.literal(commandName)
             .executes(ctx -> {
                 CommandSender sender = ctx.getSource().getSender();
-                sender.sendRichMessage(PREFIX + "Plugin version: " + plugin.getPluginMeta().getVersion());
+                sender.sendRichMessage(config.messages.prefix() + "Plugin version: " + plugin.getPluginMeta().getVersion());
                 sender.sendRichMessage("<green>🛈</green> <gray>Type <white>/junction reload</white> to reload the configuration.</gray>");
                 return Command.SINGLE_SUCCESS;
             })
@@ -31,9 +32,11 @@ public class JunctionCommand {
                 .executes(ctx -> {
                     CommandSender sender = ctx.getSource().getSender();
                     if (plugin.reload()) {
-                        sender.sendRichMessage(PREFIX + "Plugin configuration reloaded successfully.");
+                        plugin.getPluginLogger().info("Configuration reloaded by " + sender.getName());
+                        sender.sendRichMessage(config.messages.prefix() + config.messages.reloadSuccess());
                     } else {
-                        sender.sendRichMessage(PREFIX + "<red>Failed to reload config! Check console for errors.</red>");
+                        plugin.getPluginLogger().warn("Failed to reload configuration by " + sender.getName());
+                        sender.sendRichMessage(config.messages.prefix() + config.messages.reloadFail());
                     }
                     return Command.SINGLE_SUCCESS;
                 })

--- a/src/main/java/com/muhdfdeen/junction/config/Config.java
+++ b/src/main/java/com/muhdfdeen/junction/config/Config.java
@@ -31,9 +31,26 @@ public final class Config {
         String group
     ) {}
 
+    public record MessageSettings(
+        @Comment("Prefix for all messages sent by the plugin.")
+        String prefix,
+        @Comment("Message displayed when the plugin is reloaded.")
+        String reloadSuccess,
+        @Comment("Message displayed when the plugin fails to reload.")
+        String reloadFail,
+        @Comment("Message displayed when a new version of the plugin is available.")
+        String updateAvailable
+    ) {}
+
     @Configuration
     public static final class MainConfiguration extends BaseConfiguration {
         @Comment("This module automatically assigns Bedrock Edition players to a specific group.")
         public PermissionSettings permissions = new PermissionSettings(false, "LuckPerms", "geyser");
+        @Comment("Settings related to messages sent by the plugin.")
+        public MessageSettings messages = new MessageSettings(
+            "<color:#00D4FF><bold>Junction</bold> ➟ </color>",
+            "Plugin configuration has been reloaded successfully.",
+            "<red>Failed to reload plugin configuration! Check console for errors.</red>",
+            "A new version is available! <gray>(Current: <red>{current_version}</red> | Latest: <green>{latest_version}</green>)</gray>");
     }
 }

--- a/src/main/java/com/muhdfdeen/junction/listener/PlayerJoinListener.java
+++ b/src/main/java/com/muhdfdeen/junction/listener/PlayerJoinListener.java
@@ -41,7 +41,7 @@ public class PlayerJoinListener implements Listener {
         PermissionProvider permissionProvider = plugin.getPermissionProvider();
 
         if (permissionProvider == null) {
-            log.warn("Can't assign group to " + player.getName() + ", no permission provider available");
+            log.warn("Can't assign group to " + player.getName() + ", no permission provider available.");
             return;
         }
 
@@ -50,7 +50,7 @@ public class PlayerJoinListener implements Listener {
         String groupName = config.permissions.group();
 
         if (groupName == null || groupName.isEmpty()) {
-            log.error("Bedrock group name not configured, check your config file");
+            log.error("Bedrock group name not configured, check your config file.");
             return;
         }
 

--- a/src/main/java/com/muhdfdeen/junction/permission/LuckPermsProvider.java
+++ b/src/main/java/com/muhdfdeen/junction/permission/LuckPermsProvider.java
@@ -31,12 +31,12 @@ public class LuckPermsProvider implements PermissionProvider {
         LuckPerms api = provider.getProvider();
         if (groupName != null && !groupName.isEmpty()) {
             if (api.getGroupManager().getGroup(groupName) == null) {
-                log.warn("Group '" + groupName + "' not found in LuckPerms");
+                log.warn("Group '" + groupName + "' not found in LuckPerms.");
             } else {
-                log.debug("Found group '" + groupName + "' in LuckPerms");
+                log.debug("Found group '" + groupName + "' in LuckPerms.");
             }
         }
-        log.info("LuckPerms provider initialized");
+        log.info("LuckPerms provider initialized.");
         return new LuckPermsProvider(api);
     }
 

--- a/src/main/java/com/muhdfdeen/junction/permission/ProviderManager.java
+++ b/src/main/java/com/muhdfdeen/junction/permission/ProviderManager.java
@@ -11,7 +11,7 @@ public class ProviderManager {
         PermissionProvider provider = null;
 
         if (!config.permissions.enabled()) {
-            log.info("Permission management disabled");
+            log.info("Permission management disabled.");
             return null;
         }
 

--- a/src/main/java/com/muhdfdeen/junction/util/Logger.java
+++ b/src/main/java/com/muhdfdeen/junction/util/Logger.java
@@ -1,9 +1,9 @@
 package com.muhdfdeen.junction.util;
 
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import com.muhdfdeen.junction.Junction;
 import com.muhdfdeen.junction.config.Config.MainConfiguration;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Bukkit;
 
 public class Logger {
     private final Junction plugin;
@@ -12,22 +12,29 @@ public class Logger {
         this.plugin = plugin;
     }
 
+    private void log(String colorTag, String message) {
+        MainConfiguration config = plugin.getConfiguration();
+        Bukkit.getConsoleSender().sendMessage(
+            MiniMessage.miniMessage().deserialize(config.messages.prefix() + colorTag + message)
+        );
+    }
+
     public void debug(String message) {
         MainConfiguration config = plugin.getConfiguration();
         if (config != null && config.debug) {
-            plugin.getComponentLogger().info(Component.text("[DEBUG] " + message, NamedTextColor.GRAY));
+            log("<gray>[DEBUG] </gray>", message);
         }
     }
 
     public void info(String message) {
-        plugin.getComponentLogger().info(Component.text(message));
+        log("", message);
     }
 
     public void warn(String message) {
-        plugin.getComponentLogger().warn(Component.text(message));
+        log("<yellow>", message);
     }
 
     public void error(String message) {
-        plugin.getComponentLogger().error(Component.text(message));
+        log("<red>", message);
     }
 }

--- a/src/main/java/com/muhdfdeen/junction/util/UpdateChecker.java
+++ b/src/main/java/com/muhdfdeen/junction/util/UpdateChecker.java
@@ -1,0 +1,90 @@
+package com.muhdfdeen.junction.util;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.muhdfdeen.junction.Junction;
+import com.muhdfdeen.junction.config.Config.MainConfiguration;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class UpdateChecker implements Listener {
+    private final Junction plugin;
+    private boolean updateAvailable = false;
+    private String latestVersion = "";
+
+    public UpdateChecker(Junction plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        MainConfiguration config = plugin.getConfiguration();
+        Player player = event.getPlayer();
+        if (updateAvailable && player.hasPermission("junction.admin")) {
+            plugin.getPluginLogger().debug("Notifying " + player.getName() + " about available update.");
+            player.sendRichMessage(config.messages.prefix() + config.messages.updateAvailable()
+                    .replace("{current_version}", plugin.getPluginMeta().getVersion())
+                    .replace("{latest_version}", latestVersion));
+        }
+    }
+
+    public void checkForUpdates() {
+        CompletableFuture.supplyAsync(() -> {
+            try {
+                HttpClient client = HttpClient.newHttpClient();
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create("https://api.github.com/repos/muhdfdeen/junction/releases/latest"))
+                        .build();
+                HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+                if (response.statusCode() != 200) {
+                    throw new RuntimeException("GitHub returned code " + response.statusCode());
+                }
+                return response.body();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }).thenAccept(jsonResponse -> {
+            JsonObject json = JsonParser.parseString(jsonResponse).getAsJsonObject();
+            if (json.has("tag_name")) {
+                String tagName = json.get("tag_name").getAsString().replace("v", "");
+                if (isNewer(plugin.getPluginMeta().getVersion(), tagName)) {
+                    this.updateAvailable = true;
+                    this.latestVersion = tagName;
+                }
+            }
+        }).exceptionally(exception -> {
+            plugin.getPluginLogger().warn("Update check failed: " + exception.getMessage());
+            return null;
+        });
+    }
+
+    private boolean isNewer(String current, String remote) {
+        current = current.replace("v", "").split("-")[0];
+        remote = remote.replace("v", "").split("-")[0];
+        String[] currentParts = current.split("\\.");
+        String[] remoteParts = remote.split("\\.");
+
+        int length = Math.max(currentParts.length, remoteParts.length);
+        for (int i = 0; i < length; i++) {
+            int v1 = i < currentParts.length ? Integer.parseInt(currentParts[i]) : 0;
+            int v2 = i < remoteParts.length ? Integer.parseInt(remoteParts[i]) : 0;
+            if (v2 > v1) {
+                return true;
+            }
+            if (v2 < v1) {
+                return false;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
This PR adds an automatic update checker and refactors message handling.

- Implemented an asynchronous `UpdateChecker` to notify admins of new GitHub releases on join.
- Added `MessageSettings` to `config.yml` to allow customization of the prefix and system messages.
- Refactored `Logger.java` to use `Bukkit.getConsoleSender()`, enabling colored console output.
- Centralized the plugin prefix usage across commands and logs.